### PR TITLE
Add CA certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@ WORKDIR $GOPATH/src/github.com/sergiorua/kube-tagger
 
 RUN GO111MODULE=on go build main.go && ls -l && echo $GOPATH
 
+FROM debian:buster as ca-store
+RUN apt-get update && apt-get install -y ca-certificates
+
 FROM debian:buster
 RUN mkdir /app
 COPY --from=builder /go/src/github.com/sergiorua/kube-tagger/main /app/
+COPY --from=ca-store /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /app
 CMD ["./main"]


### PR DESCRIPTION
Add CA certificates to docker image to prevent following error:
```
RequestError: send request failed caused by: Post https://ec2.eu-west-1.amazonaws.com/: x509: certificate signed by unknown authority
```

Closes #5 