### PR TITLE
added || for ebs.csi.aws.com only

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 */
 func isEBSVolume(volume *v1.PersistentVolumeClaim) bool {
 	for k, v := range volume.Annotations {
-		if k == "volume.beta.kubernetes.io/storage-provisioner" && (v == "kubernetes.io/aws-ebs" || v == "kubernetes.io/ebs.csi.aws.com") {
+		if k == "volume.beta.kubernetes.io/storage-provisioner" && (v == "kubernetes.io/aws-ebs" || v == "kubernetes.io/ebs.csi.aws.com" || v == "ebs.csi.aws.com") {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 
 /*
 	This only works for EBS volumes. Make sure they are!
+	TODO: remove kuberentes.io/ebs.csi.aws.com after test
 */
 func isEBSVolume(volume *v1.PersistentVolumeClaim) bool {
 	for k, v := range volume.Annotations {

--- a/main.go
+++ b/main.go
@@ -130,11 +130,10 @@ func main() {
 
 /*
 	This only works for EBS volumes. Make sure they are!
-	TODO: remove kuberentes.io/ebs.csi.aws.com after test
 */
 func isEBSVolume(volume *v1.PersistentVolumeClaim) bool {
 	for k, v := range volume.Annotations {
-		if k == "volume.beta.kubernetes.io/storage-provisioner" && (v == "kubernetes.io/aws-ebs" || v == "kubernetes.io/ebs.csi.aws.com" || v == "ebs.csi.aws.com") {
+		if k == "volume.beta.kubernetes.io/storage-provisioner" && (v == "kubernetes.io/aws-ebs" || v == "ebs.csi.aws.com") {
 			return true
 		}
 	}


### PR DESCRIPTION
The current state does not pick up the EBS volume when created by the csi driver, this is probably due to the kubernetes.io/ in the provisioner statement. It works for aws-ebs as thats how the provisioner is called, but csi is called only by its name without the kubernetes.io in front, if that makes sense.